### PR TITLE
prototype: support syntax: "Import Foo = Bar.Baz;" for external module

### DIFF
--- a/apps/api-extractor/src/analyzer/AstImport.ts
+++ b/apps/api-extractor/src/analyzer/AstImport.ts
@@ -48,6 +48,7 @@ export interface IAstImportOptions {
   readonly importKind: AstImportKind;
   readonly modulePath: string;
   readonly exportName: string;
+  readonly exportPath?: string[];
   readonly isTypeOnly: boolean;
 }
 
@@ -86,11 +87,46 @@ export class AstImport extends AstSyntheticEntity {
    * // For AstImportKind.EqualsImport style, exportName would be "x" in this example:
    * import x = require("y");
    *
+   * import { x } from "y";
+   * import x2 = x;          // <---
+   *
+   * import * as y from "y";
+   * import x2 = y.x;        // <---
+   *
    * // For AstImportKind.ImportType style, exportName would be "a.b.c" in this example:
    * interface foo { foo: import('bar').a.b.c };
    * ```
    */
   public readonly exportName: string;
+
+  /**
+   * The path of the symbol being imported, instead of a single exportName.
+   * Normally it represents importing a deep path of an external package.
+   *
+   * @remarks
+   *
+   * ```ts
+   * // in normal cases without EqualsImport, "exportPath" contains exactly one "exportName" item
+   *
+   * // in this example, symbol "y2" will be represented as:
+   * //   - importKind: DefaultImport
+   * //   - modulePath: "m"
+   * //   - exportPath: "x.y"
+   * //   - exportName: "y"
+   * import x from "m";
+   * import y2 = x.y;
+   *
+   * // in this example with nested EqualsImport, symbol "y2" will be represented as:
+   * //   - importKind: NamedImport
+   * //   - modulePath: "m/n"
+   * //   - exportPath: "a.x.y"
+   * //   - exportName: "y"
+   * import { a } from "m/n";
+   * import b2 = a.x;
+   * import y2 = b2.y;
+   * ```
+   */
+  public readonly exportPath: string[];
 
   /**
    * Whether it is a type-only import, for example:
@@ -124,6 +160,7 @@ export class AstImport extends AstSyntheticEntity {
     this.importKind = options.importKind;
     this.modulePath = options.modulePath;
     this.exportName = options.exportName;
+    this.exportPath = options.exportPath ? options.exportPath : [options.exportName];
 
     // We start with this assumption, but it may get changed later if non-type-only import is encountered.
     this.isTypeOnlyEverywhere = options.isTypeOnly;
@@ -143,13 +180,17 @@ export class AstImport extends AstSyntheticEntity {
   public static getKey(options: IAstImportOptions): string {
     switch (options.importKind) {
       case AstImportKind.DefaultImport:
-        return `${options.modulePath}:${options.exportName}`;
+        return `${options.modulePath}:${
+          options.exportPath ? options.exportPath.join('.') : options.exportName
+        }`;
       case AstImportKind.NamedImport:
-        return `${options.modulePath}:${options.exportName}`;
+        return `${options.modulePath}:${
+          options.exportPath ? options.exportPath.join('.') : options.exportName
+        }`;
       case AstImportKind.StarImport:
-        return `${options.modulePath}:*`;
+        return `${options.modulePath}:*${options.exportPath ? options.exportPath.slice(1).join('.') : ''}`;
       case AstImportKind.EqualsImport:
-        return `${options.modulePath}:=`;
+        return `${options.modulePath}:=${options.exportPath ? options.exportPath.slice(1).join('.') : ''}`;
       case AstImportKind.ImportType: {
         const subKey: string = !options.exportName
           ? '*' // Equivalent to StarImport

--- a/apps/api-extractor/src/analyzer/AstSymbolTable.ts
+++ b/apps/api-extractor/src/analyzer/AstSymbolTable.ts
@@ -13,6 +13,7 @@ import { AstModule, AstModuleExportInfo } from './AstModule';
 import { PackageMetadataManager } from './PackageMetadataManager';
 import { ExportAnalyzer } from './ExportAnalyzer';
 import { AstEntity } from './AstEntity';
+import { AstImport } from './AstImport';
 import { AstNamespaceImport } from './AstNamespaceImport';
 import { MessageRouter } from '../collector/MessageRouter';
 import { TypeScriptInternals, IGlobalVariableAnalyzer } from './TypeScriptInternals';
@@ -192,6 +193,10 @@ export class AstSymbolTable {
       throw new InternalError('tryGetEntityForIdentifier() called for an identifier that was not analyzed');
     }
     return this._entitiesByNode.get(identifier);
+  }
+
+  public tryGetReferencedAstImport(astImport: AstImport): AstImport | undefined {
+    return this._exportAnalyzer.tryGetReferencedAstImport(astImport);
   }
 
   /**

--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -14,6 +14,7 @@ import { IFetchAstSymbolOptions } from './AstSymbolTable';
 import { AstEntity } from './AstEntity';
 import { AstNamespaceImport } from './AstNamespaceImport';
 import { SyntaxHelpers } from './SyntaxHelpers';
+import { last } from 'lodash';
 
 /**
  * Exposes the minimal APIs from AstSymbolTable that are needed by ExportAnalyzer.
@@ -750,6 +751,59 @@ export class ExportAnalyzer {
             isTypeOnly: false
           });
         }
+        // EqualsImport by namespace.
+        // EXAMPLE:
+        // import myLib2 = myLib;
+        // import B = myLib.A.B;
+      } else {
+        const reversedIdentifiers: ts.Identifier[] = [];
+        if (ts.isIdentifier(declaration.moduleReference)) {
+          reversedIdentifiers.push(declaration.moduleReference);
+        } else {
+          let current: ts.QualifiedName | undefined = declaration.moduleReference;
+          while (true) {
+            reversedIdentifiers.push(current.right);
+            if (ts.isIdentifier(current.left)) {
+              reversedIdentifiers.push(current.left);
+              break;
+            } else {
+              current = current.left;
+            }
+          }
+        }
+
+        const exportSubPath: string[] = [];
+        let externalImport: AstImport | undefined;
+        for (let i = reversedIdentifiers.length - 1; i >= 0; i--) {
+          const identifier: ts.Identifier = reversedIdentifiers[i];
+          if (!externalImport) {
+            // find the first external import as the base namespace
+            const symbol: ts.Symbol | undefined = this._typeChecker.getSymbolAtLocation(identifier);
+            if (!symbol) {
+              throw new Error('Symbol not found for identifier: ' + identifier.getText());
+            }
+            const astEntity: AstEntity | AstImport | undefined = this.fetchReferencedAstEntity(symbol, false);
+            if (astEntity instanceof AstImport) {
+              externalImport = astEntity;
+            }
+          } else {
+            exportSubPath.push(identifier.getText().trim());
+          }
+        }
+
+        if (externalImport) {
+          if (exportSubPath.length === 0) {
+            return externalImport;
+          } else {
+            return this._fetchAstImport(declarationSymbol, {
+              importKind: externalImport.importKind,
+              modulePath: externalImport.modulePath,
+              exportName: last(exportSubPath)!,
+              exportPath: externalImport.exportPath.concat(exportSubPath),
+              isTypeOnly: false
+            });
+          }
+        }
       }
     }
 
@@ -797,6 +851,25 @@ export class ExportAnalyzer {
   public tryGetExportOfAstModule(exportName: string, astModule: AstModule): AstEntity | undefined {
     const visitedAstModules: Set<AstModule> = new Set<AstModule>();
     return this._tryGetExportOfAstModule(exportName, astModule, visitedAstModules);
+  }
+
+  public tryGetReferencedAstImport(astImport: AstImport): AstImport | undefined {
+    if (astImport.exportPath) {
+      const referencedImport: AstImport | undefined = this._astImportsByKey.get(
+        AstImport.getKey({
+          importKind: astImport.importKind,
+          modulePath: astImport.modulePath,
+          exportName: astImport.exportPath[0],
+          isTypeOnly: false
+        })
+      );
+      if (referencedImport === undefined) {
+        throw new Error(
+          `For an AstImport of "EqualsImport" from namespace, there must have a referenced base AstImport.`
+        );
+      }
+      return referencedImport;
+    }
   }
 
   private _tryGetExportOfAstModule(

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -440,6 +440,13 @@ export class Collector {
           this._createEntityForIndirectReferences(referencedAstEntity, alreadySeenAstEntities);
         }
       });
+    } else if (astEntity instanceof AstImport) {
+      const referencedImport: AstImport | undefined = this.astSymbolTable.tryGetReferencedAstImport(
+        astEntity
+      );
+      if (referencedImport) {
+        this._createCollectorEntity(referencedImport, undefined);
+      }
     }
 
     if (astEntity instanceof AstNamespaceImport) {

--- a/apps/api-extractor/src/generators/ApiReportGenerator.ts
+++ b/apps/api-extractor/src/generators/ApiReportGenerator.ts
@@ -70,7 +70,7 @@ export class ApiReportGenerator {
     // Emit the imports
     for (const entity of collector.entities) {
       if (entity.astEntity instanceof AstImport) {
-        DtsEmitHelpers.emitImport(writer, entity, entity.astEntity);
+        DtsEmitHelpers.emitImport(writer, collector, entity, entity.astEntity);
       }
     }
     writer.ensureSkippedLine();

--- a/apps/api-extractor/src/generators/DtsEmitHelpers.ts
+++ b/apps/api-extractor/src/generators/DtsEmitHelpers.ts
@@ -18,9 +18,35 @@ import { SourceFileLocationFormatter } from '../analyzer/SourceFileLocationForma
 export class DtsEmitHelpers {
   public static emitImport(
     writer: IndentedWriter,
+    collector: Collector,
     collectorEntity: CollectorEntity,
     astImport: AstImport
   ): void {
+    if (astImport.exportPath.length > 1) {
+      const referencedAstImport: AstImport | undefined = collector.astSymbolTable.tryGetReferencedAstImport(
+        astImport
+      );
+      if (referencedAstImport === undefined) {
+        throw new Error(
+          `For an AstImport of "EqualsImport" from namespace, there must have a referenced base AstImport.`
+        );
+      }
+      const referencedCollectorEntity: CollectorEntity | undefined = collector.tryGetCollectorEntity(
+        referencedAstImport
+      );
+      if (referencedCollectorEntity === undefined) {
+        throw new Error(
+          `Cannot find collector entity for referenced AstImport: ${referencedAstImport.modulePath}:${referencedAstImport.exportName}`
+        );
+      }
+      writer.writeLine(
+        `import ${collectorEntity.nameForEmit} = ${
+          referencedCollectorEntity.nameForEmit
+        }.${astImport.exportPath.slice(1).join('.')};`
+      );
+      return;
+    }
+
     const importPrefix: string = astImport.isTypeOnlyEverywhere ? 'import type' : 'import';
 
     switch (astImport.importKind) {

--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -265,6 +265,11 @@ export class DtsRollupGenerator {
         span.modification.skipAll();
         break;
 
+      case ts.SyntaxKind.ImportEqualsDeclaration:
+        // Delete "import Foo = Bar.Baz;" declarations (can be inside "namespace") -- it's useless since we parsed the aliased symbol
+        span.modification.skipAll();
+        break;
+
       case ts.SyntaxKind.InterfaceKeyword:
       case ts.SyntaxKind.ClassKeyword:
       case ts.SyntaxKind.EnumKeyword:

--- a/apps/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/apps/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -108,7 +108,7 @@ export class DtsRollupGenerator {
           : ReleaseTag.None;
 
         if (this._shouldIncludeReleaseTag(maxEffectiveReleaseTag, dtsKind)) {
-          DtsEmitHelpers.emitImport(writer, entity, astImport);
+          DtsEmitHelpers.emitImport(writer, collector, entity, astImport);
         }
       }
     }


### PR DESCRIPTION
**fix issue:**
https://github.com/microsoft/rushstack/issues/2005

**The design:**
For the case:
```ts
import { A } from 'foo';
import E = A.B.C.D;
export { E };
```

The symbol `E` actually means importing something from the external package `foo`. The detail external import is: import `A` from package `foo`, and extract content under path `.B.C.D`.

So extending `AstImport` definition, replace `"exportName": string` to new `"exportPath": string[]` field, indicating the actual/entire import path.
`"exportPath"` and the original `"exportName"` have the same meaning: which part is exported/imported from the package.


**how it is done:**
* **Definition:** Extending `AstImport` definition, now it contains fields:
  * `"importKind"`: unchanged
  * `"modulePath"`: unchanged
  * `"exportPath"`: extended from `"exportName"` as a single `string` to a path as `string[]` 
* **Analyze:** When visiting `Import A = B.C.D;` declaration for the symbol `"A"`, recursively looking for an external import from left to right inside the referenced path `"B.C.D"`. And if we find one, build a new `AstImport` by cloning it and appending rest path to its `"exportPath"`. For examples:
  * If we find symbol `"B"` with `AstImport`: `{ importKind: DefaultImport, modulePath: 'mod', exportPath: ["b"]  }`, we build new `AstImport` for symbol `"A"`: `{ importKind: DefaultImport, modulePath: 'mod', exportPath: ["b", "C", "D"]  }`
  * If we cannot find external import for symbol `"B"`, but find symbol `"C"` with `AstImport`: `{ importKind: NamedImport, modulePath: 'modC', exportPath: ["x", "y", "z"]  }`, we build new `AstImport` for symbol `"A"`: `{ importKind: NamedImport, modulePath: 'modC', exportPath: [""x", "y", "z", "D"]  }`
* **Collect Reference:**: when collect referenced entities, for `AstImport` with multi-parts `"exportPath"`, we should create collector entity for its referenced "base" import, that is, the `AstImport` with a single-part `"exportPath"`. (We need that declaration for output)
* **Generate:**
  * for `AstImport` with `"exportPath"` of a single `string`, generate result as previous version
  * for `AstImport` with multi-parts `"exportPath"`, generate a normal import, and another EqualsImport with identifiers:
    ```ts
    import { A } from 'foo';  // previously generated for referenced "base" AstImport entity
    import X = A.B.C.D;  // generate for this multi-part "exportPath" AstImport
    ```
